### PR TITLE
Update metadata.json with missing artifactJsonType attribute

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,6 @@
 {
   "clientSchemaVersion": 1,
   "serverSchemaVersion": 6,
-  "fileFormatVersion": 5
+  "fileFormatVersion": 5,
+  "artifactJsonType": "APPLICATION"
 }


### PR DESCRIPTION
**Summary**
Add the missing `"artifactJsonType": "APPLICATION"` field to this repo’s `metadata.json` to fix the import error.

**Change**

* Insert `"artifactJsonType": "APPLICATION"` into `metadata.json`.
